### PR TITLE
Fix deprecated display size

### DIFF
--- a/android/src/main/java/io/github/ackeecz/extensions/android/ContextExtensions.kt
+++ b/android/src/main/java/io/github/ackeecz/extensions/android/ContextExtensions.kt
@@ -140,10 +140,15 @@ fun Context.openPlayStore(): Boolean {
     }
 }
 
+@Suppress("DEPRECATION")
 private fun Context.getDisplaySize(): Point {
-    val display = (getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
-    val size = Point()
-    display.getSize(size)
-
-    return size
+     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+         val windowBounds = (getSystemService(Context.WINDOW_SERVICE) as WindowManager).currentWindowMetrics.bounds
+         Point(windowBounds.width(), windowBounds.height())
+    } else {
+         val display = (getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+         val size = Point()
+         display.getSize(size)
+         size
+    }
 }

--- a/lib.properties
+++ b/lib.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ackeecz
-VERSION_NAME=2.1.0
+VERSION_NAME=2.1.1
 VERSION_CODE=1
 SITE_URL=https://github.com/AckeeCZ/kotlin-extensions
 POM_DEVELOPER_ID=ackee


### PR DESCRIPTION
On API > 30 apps should use currentWindowMetrics.bounds instead to get the correct values